### PR TITLE
[Add] Swizzling component of `Not Found`

### DIFF
--- a/src/theme/NotFound/Content/index.tsx
+++ b/src/theme/NotFound/Content/index.tsx
@@ -1,0 +1,92 @@
+import clsx from 'clsx'
+
+import Translate from '@docusaurus/Translate'
+import Heading from '@theme/Heading'
+import BrowserOnly from '@docusaurus/BrowserOnly'
+
+import type { Props } from '@theme/NotFound/Content'
+
+export default function NotFoundContent({ className }: Props): JSX.Element {
+    return (
+        <main className={clsx('container margin-vert--xl', className)}>
+            <div className='row'>
+                <div className='col col--6 col--offset-3'>
+                    <Heading as='h1' className='hero__title'>
+                        <Translate
+                            id='theme.NotFound.title'
+                            description='The title of the 404 page'
+                        >
+                            Page Not Found
+                        </Translate>
+                    </Heading>
+                    <p>
+                        <Translate
+                            id='theme.NotFound.p1'
+                            description='The first paragraph of the 404 page'
+                        >
+                            We could not find what you were looking for.
+                        </Translate>
+                    </p>
+                    <p>
+                        <Translate
+                            id='theme.NotFound.p2'
+                            description='The 2nd paragraph of the 404 page'
+                        >
+                            Please contact the owner of the site that linked
+                            you to the original URL and let them know their
+                            link is broken.
+                        </Translate>
+                    </p>
+                    <div>
+                        <UserFlowToArchivingSite />
+                    </div>
+                </div>
+            </div>
+        </main>
+    )
+}
+
+function UserFlowToArchivingSite(): JSX.Element {
+    // cf. https://docusaurus.io/docs/docusaurus-core#browseronly
+    return <BrowserOnly>{() => <LinkToArchivingSite />}</BrowserOnly>
+}
+
+function LinkToArchivingSite(): JSX.Element {
+    const { origin, pathname, search } = window.location
+    const url = [origin, pathname, search].join('')
+
+    return (
+        <>
+            <p>または、各アーカイブサイトをご確認ください:</p>
+            <ul>
+                <li>
+                    <a
+                        href={`https://gyo.tc/${url}`}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                    >
+                        ウェブ魚拓
+                    </a>
+                </li>
+                <li>
+                    <a
+                        href={`https://web.archive.org/web/*/${url}`}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                    >
+                        Internet Archive
+                    </a>
+                </li>
+                <li>
+                    <a
+                        href={`https://archive.md/${url}`}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                    >
+                        archive.today
+                    </a>
+                </li>
+            </ul>
+        </>
+    )
+}


### PR DESCRIPTION
<!--
    PR を出す前に、まずは以下の記事を読むこと：
        - [レビューしてもらいやすいPRの書き方 - hydrakecat’s blog](https://hydrakecat.hatenablog.jp/entry/2018/06/30/レビューしてもらいやすいPRの書き方)

    自己点検の後、問題がないと判断できてからPRを出すことを期待
-->

## Summary <!-- 変更の概要 -->

- `NotFound/Content` を swizzle して必要情報を追記した

## Why make this change? <!-- なぜこの変更をするのか -->

毎日・毎週という頻度でページ内容を更新していくに当たって、
SNSで共有された過去のURLへのアクセスがあったときに "404: Page Not Found" では体験が悪い

しかしそれを見せることも敵わないため、代わりに魚拓への導線を配置した

- cf. #5 

## What I did <!-- やったこと -->

- [x] `npm run swizzle @docusaurus/theme-classic NotFound/Content -- --typescript`
- [x] component の実装

- [ ] 過去ページのアーカイブ登録

→ ページのアーカイビングそれ自体はボランティアベースでやってもらうしかない 

## Description of the change <!-- 変更内容 -->

Not Found ページの最下部に文言が追加されるようになった：

- または、各アーカイブサイトをご確認ください:
    - ウェブ魚拓
    - Internet Archive
    - archive.today

## Scope of Impact <!-- 影響範囲 -->

なし

## Usage <!-- どうやるのか -->

- `npm run start` してローカルサーバを起動した後、存在しないページにアクセスする

## Issue <!-- 課題 -->

「ボランティアベース」でやるなら、その周知をする必要がありそう

## Remarks <!-- 備考 -->

archive.today だと js も保存するので、SSG に最適かも？

<!--
    参考文献:
        - [【GitHub】プルリクエストの書き方とテンプレート - applis](https://applis.io/posts/how-to-write-git-pull-request)
-->
